### PR TITLE
Add a feature to pass additional environment vars to subcommand

### DIFF
--- a/examples/facade-env-sub-command
+++ b/examples/facade-env-sub-command
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo $0
+echo $1
+
+env | grep FACADE_
+
+exit

--- a/examples/facade-env.go
+++ b/examples/facade-env.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	f := &facade.Facade{}
-	f.Environment = map[string]string{
+	f.Env = map[string]string{
 		"FACADE_FOO": "123",
 		"FACADE_BAR": "Bar Value",
 	}

--- a/examples/facade-env.go
+++ b/examples/facade-env.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/kentaro/facade"
+)
+
+func main() {
+	f := &facade.Facade{}
+	f.Environment = map[string]string{
+		"FACADE_FOO": "123",
+		"FACADE_BAR": "Bar Value",
+	}
+
+	f.Run()
+}

--- a/facade.go
+++ b/facade.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 type Facade struct {
-	Environment map[string]string
+	Env map[string]string
 }
 
 func (f *Facade) Run() {
@@ -25,9 +25,9 @@ func (f *Facade) Run() {
 	full := fmt.Sprintf("%s-%s", me, sub)
 
 	cmd := exec.Command(full, os.Args[2:]...)
-	if f.Environment != nil {
+	if f.Env != nil {
 		newenv := os.Environ()
-		for k, v := range f.Environment {
+		for k, v := range f.Env {
 			newenv = append(newenv, fmt.Sprintf("%s=%s", k, v))
 		}
 		cmd.Env = newenv

--- a/facade.go
+++ b/facade.go
@@ -14,6 +14,14 @@ func init() {
 	log.SetOutput(colorable.NewColorableStdout())
 }
 
+type Facade struct {
+	Environment map[string]string
+}
+
+func (d *Facade) Run() {
+
+}
+
 func Run() {
 	chunks := strings.Split(os.Args[0], string(os.PathSeparator))
 	me := chunks[len(chunks)-1]

--- a/facade.go
+++ b/facade.go
@@ -18,13 +18,21 @@ type Facade struct {
 	Environment map[string]string
 }
 
-func (d *Facade) Run() {
+func (f *Facade) Run() {
 	chunks := strings.Split(os.Args[0], string(os.PathSeparator))
 	me := chunks[len(chunks)-1]
 	sub := os.Args[1]
 	full := fmt.Sprintf("%s-%s", me, sub)
 
 	cmd := exec.Command(full, os.Args[2:]...)
+	if f.Environment != nil {
+		newenv := os.Environ()
+		for k, v := range f.Environment {
+			newenv = append(newenv, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmd.Env = newenv
+	}
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		fatal(err.Error())

--- a/facade.go
+++ b/facade.go
@@ -19,10 +19,6 @@ type Facade struct {
 }
 
 func (d *Facade) Run() {
-
-}
-
-func Run() {
 	chunks := strings.Split(os.Args[0], string(os.PathSeparator))
 	me := chunks[len(chunks)-1]
 	sub := os.Args[1]
@@ -51,6 +47,11 @@ func Run() {
 		fatal(err.Error())
 		os.Exit(1)
 	}
+}
+
+func Run() {
+	f := &Facade{}
+	f.Run()
 }
 
 func readFrom(in io.ReadCloser, logger func(string)) {


### PR DESCRIPTION
I suppose this feature is used like: https://github.com/kentaro/facade/blob/b95d54ef7a46f3de0e4a4b31970fa0642171a8ea/examples/facade-env.go

This may be useful when this library is used as a framework.
